### PR TITLE
feat: Replace prompt-based editing with inline editing for todos

### DIFF
--- a/src/components/ToDo.tsx
+++ b/src/components/ToDo.tsx
@@ -14,6 +14,10 @@ const TodoApp = () => {
     // Holds current value of new to-do input field
     const [newTodo, setNewTodo] = useState<string>("");
 
+    // States for inline editing
+    const [editId, setEditId] = useState<string | null>(null);
+    const [draftText, setDraftText] = useState<string>("");
+
 
     // Function to validate new to-do input
     const validNewTodo = () => newTodo.trim().length > 0; 
@@ -63,6 +67,19 @@ const TodoApp = () => {
         setTodos(updatedTodos); // Updates the state with the modified list
     };
 
+    // On key down handler for editing
+    const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === 'Enter' && draftText.trim().length > 0 && editId !== null) { // If Enter is pressed and draftText is not empty
+        editTodo(editId, draftText.trim()); // Save the changes
+        setEditId(null); // Exit edit mode
+        setDraftText(""); // Clear draft text
+      }
+      if (e.key === 'Escape') { // If Escape is pressed
+        setEditId(null); // Exit edit mode without saving
+        setDraftText(""); // Clear draft text
+      }
+    }
+
     return (
     <div className="board">
        <div className="column">
@@ -95,17 +112,31 @@ const TodoApp = () => {
                                                             with the item's ID as argument */
                />
                {/* If item is completed, text is shown with a line through it */}
-               <span 
-                 className="text"
-                 onClick={() => {
-                   const next = prompt("Edit to-do:", todo.text);
-                   if (next !== null) {
-                     editTodo(todo.id, next);
-                   }
-                 }}
-               >
-                 {todo.text} {/* Displays the text of the to-do item */}
-               </span>
+              {editId === todo.id ? ( // If the current item is being edited
+                <input 
+                className="input"
+                value={draftText} 
+                autoFocus
+                onKeyDown={(e) => handleKeyDown(e)}
+                onChange={(e) => setDraftText(e.target.value)}
+                onBlur={() => { // When input loses focus, save changes if valid
+                  if (draftText.trim().length > 0 && editId) { // Ensure editId is not null
+                    editTodo(editId, draftText.trim()); // Save the changes
+                  }
+                  setEditId(null); 
+                  setDraftText(""); 
+                }}></input>
+              ) : (
+                <span
+                  className="text"
+                  onClick={() => { // When user clicks on the text, enable edit mode 
+                    setEditId(todo.id);
+                    setDraftText(todo.text);
+                  }}
+                >
+                  {todo.text}
+                </span>
+              )}
                <button className="btn btn-danger" onClick={() => removeTodo(todo.id)}>Remove</button> {/* When user clicks button, removeTodo function runs
                                                                           with the item's ID as argument */}
              </li>


### PR DESCRIPTION
- Add inline editing state management (editId, draftText)
  - Enable click-to-edit functionality on todo items
  - Add keyboard shortcuts (Enter to save, Escape to cancel)
  - Auto-save on blur when input loses focus
  - Remove disruptive browser prompt dialog

Closes #11

  This implements a more user-friendly inline editing experience where users can click directly on a
   todo item to edit it in place, rather than using a browser prompt.